### PR TITLE
Feature/export to svg and png

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "better-react-mathjax": "^2.0.3",
+        "mathjax": "^3.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2743,6 +2744,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/mathjax": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz",
+      "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==",
+      "license": "Apache-2.0"
     },
     "node_modules/mathjax-full": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "better-react-mathjax": "^2.0.3",
+    "mathjax": "^3.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/components/Downloads/ExportToPng.tsx
+++ b/src/components/Downloads/ExportToPng.tsx
@@ -5,6 +5,7 @@ import { SVG } from 'mathjax-full/js/output/svg.js';
 import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor.js';
 import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
 import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+import cn from '../../lib/cn';
 
 export default function ExportToPng(props: { children: string }) {
   const { children } = props;
@@ -99,7 +100,10 @@ export default function ExportToPng(props: { children: string }) {
     <div>
       <button 
         onClick={convertLatexToPNG} 
-        className="border-2 border-gray-300 rounded-md p-2 mt-4"
+        className={cn(
+          "border-2 border-gray-300 rounded-md p-2 mt-4",
+          "hover:bg-gray-300"
+        )}
       >
         export to PNG
       </button>

--- a/src/components/Downloads/ExportToPng.tsx
+++ b/src/components/Downloads/ExportToPng.tsx
@@ -1,0 +1,109 @@
+import React, { useRef } from 'react';
+import { mathjax } from 'mathjax-full/js/mathjax.js';
+import { TeX } from 'mathjax-full/js/input/tex.js';
+import { SVG } from 'mathjax-full/js/output/svg.js';
+import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor.js';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+
+export default function ExportToPng(props: { children: string }) {
+  const { children } = props;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const convertLatexToPNG = () => {
+    const adaptor = browserAdaptor();
+    RegisterHTMLHandler(adaptor);
+
+    const texInput = new TeX({ packages: AllPackages });
+    const svgOutput = new SVG({ fontCache: 'none' });
+
+    const html = mathjax.document(document, {
+      InputJax: texInput,
+      OutputJax: svgOutput,
+    });
+
+    // LaTeX를 SVG로 변환하여 실제 DOM에 추가
+    const node = html.convert(children, { display: true });
+    if (containerRef.current) {
+      containerRef.current.innerHTML = '';
+      containerRef.current.appendChild(node);
+    }
+
+    // 다음 프레임에서 실행하여 SVG가 렌더링되도록 함
+    requestAnimationFrame(() => {
+      if (!containerRef.current) {
+        console.error('컨테이너를 찾을 수 없습니다.');
+        return;
+      }
+
+      const svgElement = containerRef.current.querySelector('svg');
+      if (!svgElement) {
+        console.error('SVG 요소를 찾을 수 없습니다.');
+        return;
+      }
+
+      // SVG 요소를 직렬화
+      const data = new XMLSerializer().serializeToString(svgElement);
+      const svgDataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(data);
+
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+
+      if (!ctx) {
+        console.error('2D 컨텍스트를 가져올 수 없습니다.');
+        return;
+      }
+
+      const img = new Image();
+
+      // CORS 설정
+      img.crossOrigin = 'Anonymous';
+
+      img.onload = () => {
+        // 이미지 크기 설정
+        canvas.width = img.width;
+        canvas.height = img.height;
+
+        ctx.drawImage(img, 0, 0);
+
+        // PNG 데이터 URL 생성
+        canvas.toBlob((blob) => {
+          if (blob) {
+            const url = URL.createObjectURL(blob);
+
+            // 다운로드 링크 생성 및 클릭
+            const link = document.createElement('a');
+            link.download = 'equation.png';
+            link.href = url;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+
+            // 메모리 정리
+            URL.revokeObjectURL(url);
+          } else {
+            console.error('Blob 생성 실패');
+          }
+        }, 'image/png');
+      };
+
+      img.onerror = (err) => {
+        console.error('이미지 로드 중 오류 발생:', err);
+      };
+
+      img.src = svgDataUrl;
+    });
+  };
+
+  return (
+    <div>
+      <button 
+        onClick={convertLatexToPNG} 
+        className="border-2 border-gray-300 rounded-md p-2 mt-4"
+      >
+        export to PNG
+      </button>
+      <div ref={containerRef} style={{ display: 'none' }}></div>
+    </div>
+  );
+}

--- a/src/components/Downloads/ExportToSvg.tsx
+++ b/src/components/Downloads/ExportToSvg.tsx
@@ -4,6 +4,7 @@ import { SVG } from 'mathjax-full/js/output/svg.js';
 import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
 import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
 import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+import cn from '../../lib/cn';
 
 export default function ExportToSvg({ children }: { children: string }) {
   const convertLatexToSVG = () => {
@@ -30,7 +31,13 @@ export default function ExportToSvg({ children }: { children: string }) {
   };
 
   return (
-    <button onClick={convertLatexToSVG} className="border-2 border-gray-300 rounded-md p-2 mt-4">
+    <button 
+      onClick={convertLatexToSVG} 
+      className={cn(
+        "border-2 border-gray-300 rounded-md p-2 mt-4",
+        "hover:bg-gray-300"
+      )}
+    >
       Export to SVG
     </button>
   );

--- a/src/components/Downloads/ExportToSvg.tsx
+++ b/src/components/Downloads/ExportToSvg.tsx
@@ -1,0 +1,37 @@
+import { mathjax } from 'mathjax-full/js/mathjax.js';
+import { TeX } from 'mathjax-full/js/input/tex.js';
+import { SVG } from 'mathjax-full/js/output/svg.js';
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+
+export default function ExportToSvg({ children }: { children: string }) {
+  const convertLatexToSVG = () => {
+    const adaptor = liteAdaptor();
+    RegisterHTMLHandler(adaptor);
+
+    const texInput = new TeX({ packages: AllPackages });
+    const svgOutput = new SVG({ fontCache: 'local' });
+
+    const mathDocument = mathjax.document('', {
+      InputJax: texInput,
+      OutputJax: svgOutput,
+    });
+
+    const node = mathDocument.convert(children, { display: true });
+    const svgData = adaptor.outerHTML(node);
+    const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'equation.svg';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button onClick={convertLatexToSVG} className="border-2 border-gray-300 rounded-md p-2 mt-4">
+      Export to SVG
+    </button>
+  );
+}

--- a/src/components/Equation.tsx
+++ b/src/components/Equation.tsx
@@ -1,44 +1,7 @@
-import { useEffect } from "react";
 import { MathJax, MathJaxContext } from "better-react-mathjax";
-import { mathjax } from 'mathjax-full/js/mathjax.js';
-import { TeX } from 'mathjax-full/js/input/tex.js';
-import { SVG } from 'mathjax-full/js/output/svg.js';
-import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
-import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
-import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+import ExportToSvg from './Downloads/ExportToSvg';
 
-export default function Equation({
-  children,
-  fontSize,
-}: {
-  children: string;
-  fontSize: number;
-}) {
-  const adaptor = liteAdaptor();
-  RegisterHTMLHandler(adaptor);
-
-  const texInput = new TeX({ packages: AllPackages });
-  const svgOutput = new SVG({ fontCache: 'local' });
-
-  const mathDocument = mathjax.document('', {
-    InputJax: texInput,
-    OutputJax: svgOutput,
-  });
-
-  const convertLatexToSVG = () => {
-    const node = mathDocument.convert(children, {
-      display: true,
-    });
-    const svgData = adaptor.outerHTML(node);
-    const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'equation.svg';
-    link.click();
-    URL.revokeObjectURL(url);
-  };
-
+export default function Equation({ children, fontSize }: { children: string; fontSize: number }) {
   return (
     <div className="mt-8">
       <MathJaxContext>
@@ -55,12 +18,7 @@ export default function Equation({
         </MathJax>
       </MathJaxContext>
 
-      <button
-        onClick={convertLatexToSVG}
-        className="border-2 border-gray-300 rounded-md p-2 mt-4"
-      >
-        export to SVG
-      </button>
+      <ExportToSvg children={children} />
     </div>
   );
 }

--- a/src/components/Equation.tsx
+++ b/src/components/Equation.tsx
@@ -1,4 +1,11 @@
-import { MathJax } from "better-react-mathjax";
+import { useEffect } from "react";
+import { MathJax, MathJaxContext } from "better-react-mathjax";
+import { mathjax } from 'mathjax-full/js/mathjax.js';
+import { TeX } from 'mathjax-full/js/input/tex.js';
+import { SVG } from 'mathjax-full/js/output/svg.js';
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
 
 export default function Equation({
   children,
@@ -7,17 +14,53 @@ export default function Equation({
   children: string;
   fontSize: number;
 }) {
+  const adaptor = liteAdaptor();
+  RegisterHTMLHandler(adaptor);
+
+  const texInput = new TeX({ packages: AllPackages });
+  const svgOutput = new SVG({ fontCache: 'local' });
+
+  const mathDocument = mathjax.document('', {
+    InputJax: texInput,
+    OutputJax: svgOutput,
+  });
+
+  const convertLatexToSVG = () => {
+    const node = mathDocument.convert(children, {
+      display: true,
+    });
+    const svgData = adaptor.outerHTML(node);
+    const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'equation.svg';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="mt-8">
-      <MathJax
-        style={{
-          fontSize: `${fontSize}px`,
-          color: "black",
-          backgroundColor: "white",
-          padding: "0.5rem",
-          borderRadius: "0.5rem",
-        }}
-      >{`\\[ ${children} \\]`}</MathJax>
+      <MathJaxContext>
+        <MathJax
+          style={{
+            fontSize: `${fontSize}px`,
+            color: 'black',
+            backgroundColor: 'white',
+            padding: '0.5rem',
+            borderRadius: '0.5rem',
+          }}
+        >
+          {`\\[ ${children} \\]`}
+        </MathJax>
+      </MathJaxContext>
+
+      <button
+        onClick={convertLatexToSVG}
+        className="border-2 border-gray-300 rounded-md p-2 mt-4"
+      >
+        export to SVG
+      </button>
     </div>
   );
 }

--- a/src/components/Equation.tsx
+++ b/src/components/Equation.tsx
@@ -18,9 +18,10 @@ export default function Equation({ children, fontSize }: { children: string; fon
           {`\\[ ${children} \\]`}
         </MathJax>
       </MathJaxContext>
-
-      <ExportToSvg children={children} />
-      <ExportToPng children={children} />
+      <div className="flex flex-col-2 gap-2">
+        <ExportToSvg children={children} />
+        <ExportToPng children={children} />
+      </div>
     </div>
   );
 }

--- a/src/components/Equation.tsx
+++ b/src/components/Equation.tsx
@@ -1,5 +1,6 @@
 import { MathJax, MathJaxContext } from "better-react-mathjax";
 import ExportToSvg from './Downloads/ExportToSvg';
+import ExportToPng from './Downloads/ExportToPng';
 
 export default function Equation({ children, fontSize }: { children: string; fontSize: number }) {
   return (
@@ -19,6 +20,7 @@ export default function Equation({ children, fontSize }: { children: string; fon
       </MathJaxContext>
 
       <ExportToSvg children={children} />
+      <ExportToPng children={children} />
     </div>
   );
 }

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export default function cn(...classNames: (string | undefined)[]): string {
+  return classNames.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
![스크린샷 2024-10-03 오후 4 02 41](https://github.com/user-attachments/assets/1406c30a-29a4-4d27-b41e-b240b8797d52)

- SVG, PNG 다운로드
  - PNG 코드에 `useRef` 있긴함;;
- 버튼 로직들 `componentes/Downloads`폴더 안에 넣어놈
- 버튼 호버시 회색으로 칠하기
- `flex-col-2`로 가로로 배치