### PR TITLE
Feature/fontsize sync to export result

### DIFF
--- a/src/components/Downloads/ExportToPng.tsx
+++ b/src/components/Downloads/ExportToPng.tsx
@@ -7,8 +7,12 @@ import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
 import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
 import cn from '../../lib/cn';
 
-export default function ExportToPng(props: { children: string }) {
-  const { children } = props;
+interface ExportToPngProps {
+  children: string;
+  fontsize: number;
+}
+
+export default function ExportToPng({children, fontsize}: ExportToPngProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const convertLatexToPNG = () => {
@@ -28,6 +32,12 @@ export default function ExportToPng(props: { children: string }) {
     if (containerRef.current) {
       containerRef.current.innerHTML = '';
       containerRef.current.appendChild(node);
+
+      // SVG에 fontsize를 적용
+      const svgElement = containerRef.current.querySelector('svg');
+      if (svgElement) {
+        svgElement.style.fontSize = `${fontsize}px`;
+      }
     }
 
     // 다음 프레임에서 실행하여 SVG가 렌더링되도록 함
@@ -98,7 +108,7 @@ export default function ExportToPng(props: { children: string }) {
 
   return (
     <div>
-      <button 
+      <button   
         onClick={convertLatexToPNG} 
         className={cn(
           "border-2 border-gray-300 rounded-md p-2 mt-4",

--- a/src/components/Downloads/ExportToPng.tsx
+++ b/src/components/Downloads/ExportToPng.tsx
@@ -1,10 +1,5 @@
-import React, { useRef } from 'react';
-import { mathjax } from 'mathjax-full/js/mathjax.js';
-import { TeX } from 'mathjax-full/js/input/tex.js';
-import { SVG } from 'mathjax-full/js/output/svg.js';
-import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor.js';
-import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
-import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+import { useRef } from 'react';
+import { convertLatexToSVG } from '../../lib/LatexToSvg';
 import cn from '../../lib/cn';
 
 interface ExportToPngProps {
@@ -12,47 +7,13 @@ interface ExportToPngProps {
   fontsize: number;
 }
 
-export default function ExportToPng({children, fontsize}: ExportToPngProps) {
+export default function ExportToPng({ children, fontsize }: ExportToPngProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const convertLatexToPNG = () => {
-    const adaptor = browserAdaptor();
-    RegisterHTMLHandler(adaptor);
+  const handleExportToPng = () => {
+    const svgElement = convertLatexToSVG(children, fontsize, containerRef);
 
-    const texInput = new TeX({ packages: AllPackages });
-    const svgOutput = new SVG({ fontCache: 'none' });
-
-    const html = mathjax.document(document, {
-      InputJax: texInput,
-      OutputJax: svgOutput,
-    });
-
-    // LaTeX를 SVG로 변환하여 실제 DOM에 추가
-    const node = html.convert(children, { display: true });
-    if (containerRef.current) {
-      containerRef.current.innerHTML = '';
-      containerRef.current.appendChild(node);
-
-      // SVG에 fontsize를 적용
-      const svgElement = containerRef.current.querySelector('svg');
-      if (svgElement) {
-        svgElement.style.fontSize = `${fontsize}px`;
-      }
-    }
-
-    // 다음 프레임에서 실행하여 SVG가 렌더링되도록 함
-    requestAnimationFrame(() => {
-      if (!containerRef.current) {
-        console.error('컨테이너를 찾을 수 없습니다.');
-        return;
-      }
-
-      const svgElement = containerRef.current.querySelector('svg');
-      if (!svgElement) {
-        console.error('SVG 요소를 찾을 수 없습니다.');
-        return;
-      }
-
+    if (svgElement) {
       // SVG 요소를 직렬화
       const data = new XMLSerializer().serializeToString(svgElement);
       const svgDataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(data);
@@ -103,13 +64,13 @@ export default function ExportToPng({children, fontsize}: ExportToPngProps) {
       };
 
       img.src = svgDataUrl;
-    });
+    }
   };
 
   return (
     <div>
       <button   
-        onClick={convertLatexToPNG} 
+        onClick={handleExportToPng} 
         className={cn(
           "border-2 border-gray-300 rounded-md p-2 mt-4",
           "hover:bg-gray-300"

--- a/src/components/Downloads/ExportToSvg.tsx
+++ b/src/components/Downloads/ExportToSvg.tsx
@@ -1,39 +1,60 @@
+import React, { useRef } from 'react';
 import { mathjax } from 'mathjax-full/js/mathjax.js';
 import { TeX } from 'mathjax-full/js/input/tex.js';
 import { SVG } from 'mathjax-full/js/output/svg.js';
-import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
+import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor.js';
 import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
 import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
 import cn from '../../lib/cn';
 
-export default function ExportToSvg({
-  children,
-}: {
+interface ExportToSvgProps {
   children: string;
-}) {
-  const adaptor = liteAdaptor();
-  RegisterHTMLHandler(adaptor);
+  fontsize: number;
+}
 
-  const texInput = new TeX({ packages: AllPackages });
-  const svgOutput = new SVG({ fontCache: 'local' });
-
-  const mathDocument = mathjax.document('', {
-    InputJax: texInput,
-    OutputJax: svgOutput,
-  });
+export default function ExportToSvg({ children, fontsize }: ExportToSvgProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const convertLatexToSVG = () => {
-    const node = mathDocument.convert(children, {
-      display: true,
+    const adaptor = browserAdaptor();
+    RegisterHTMLHandler(adaptor);
+
+    const texInput = new TeX({ packages: AllPackages });
+    const svgOutput = new SVG({ fontCache: 'none' });
+
+    const html = mathjax.document(document, {
+      InputJax: texInput,
+      OutputJax: svgOutput,
     });
-    const svgData = adaptor.outerHTML(node);
-    const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'equation.svg';
-    link.click();
-    URL.revokeObjectURL(url);
+
+    // LaTeX를 SVG로 변환하여 실제 DOM에 추가
+    const node = html.convert(children, { display: true });
+    if (containerRef.current) {
+      containerRef.current.innerHTML = '';
+      containerRef.current.appendChild(node);
+
+      // SVG에 fontsize를 적용
+      const svgElement = containerRef.current.querySelector('svg');
+      
+      // null 체크 후 동작 진행
+      if (svgElement) {
+        svgElement.style.fontSize = `${fontsize}px`;
+
+        // SVG 데이터를 직렬화하여 Blob 생성
+        const svgData = new XMLSerializer().serializeToString(svgElement);
+        const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+
+        // 다운로드 링크 생성 및 클릭
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'equation.svg';
+        link.click();
+        URL.revokeObjectURL(url);
+      } else {
+        console.error('SVG 요소를 찾을 수 없습니다.');
+      }
+    }
   };
 
   return (
@@ -47,6 +68,7 @@ export default function ExportToSvg({
       >
         export to SVG
       </button>
+      <div ref={containerRef} style={{ display: 'none' }}></div>
     </div>
   );
 }

--- a/src/components/Downloads/ExportToSvg.tsx
+++ b/src/components/Downloads/ExportToSvg.tsx
@@ -1,10 +1,5 @@
-import React, { useRef } from 'react';
-import { mathjax } from 'mathjax-full/js/mathjax.js';
-import { TeX } from 'mathjax-full/js/input/tex.js';
-import { SVG } from 'mathjax-full/js/output/svg.js';
-import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor.js';
-import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
-import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+import { useRef } from 'react';
+import { convertLatexToSVG } from '../../lib/LatexToSvg';
 import cn from '../../lib/cn';
 
 interface ExportToSvgProps {
@@ -15,52 +10,30 @@ interface ExportToSvgProps {
 export default function ExportToSvg({ children, fontsize }: ExportToSvgProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const convertLatexToSVG = () => {
-    const adaptor = browserAdaptor();
-    RegisterHTMLHandler(adaptor);
+  const handleExportToSvg = () => {
+    const svgElement = convertLatexToSVG(children, fontsize, containerRef);
+    
+    if (svgElement) {
+      // SVG 데이터를 직렬화하여 Blob 생성
+      const svgData = new XMLSerializer().serializeToString(svgElement);
+      const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
 
-    const texInput = new TeX({ packages: AllPackages });
-    const svgOutput = new SVG({ fontCache: 'none' });
-
-    const html = mathjax.document(document, {
-      InputJax: texInput,
-      OutputJax: svgOutput,
-    });
-
-    // LaTeX를 SVG로 변환하여 실제 DOM에 추가
-    const node = html.convert(children, { display: true });
-    if (containerRef.current) {
-      containerRef.current.innerHTML = '';
-      containerRef.current.appendChild(node);
-
-      // SVG에 fontsize를 적용
-      const svgElement = containerRef.current.querySelector('svg');
-      
-      // null 체크 후 동작 진행
-      if (svgElement) {
-        svgElement.style.fontSize = `${fontsize}px`;
-
-        // SVG 데이터를 직렬화하여 Blob 생성
-        const svgData = new XMLSerializer().serializeToString(svgElement);
-        const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-
-        // 다운로드 링크 생성 및 클릭
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'equation.svg';
-        link.click();
-        URL.revokeObjectURL(url);
-      } else {
-        console.error('SVG 요소를 찾을 수 없습니다.');
-      }
+      // 다운로드 링크 생성 및 클릭
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'equation.svg';
+      link.click();
+      URL.revokeObjectURL(url);
+    } else {
+      console.error('SVG 요소를 찾을 수 없습니다.');
     }
   };
 
   return (
     <div>
       <button
-        onClick={convertLatexToSVG}
+        onClick={handleExportToSvg}
         className={cn(
           "border-2 border-gray-300 rounded-md p-2 mt-4",
           "hover:bg-gray-300"

--- a/src/components/Equation.tsx
+++ b/src/components/Equation.tsx
@@ -24,8 +24,8 @@ export default function Equation({
         {`\\[ ${children} \\]`}
       </MathJax>
       <div className="flex justify-center flex-col-2 gap-2">
-        <ExportToSvg children={children} />
-        <ExportToPng children={children} />
+        <ExportToSvg children={children} fontsize={fontSize}/>
+        <ExportToPng children={children} fontsize={fontSize}/>
       </div>
     </div>
   );

--- a/src/lib/LatexToSvg.ts
+++ b/src/lib/LatexToSvg.ts
@@ -1,0 +1,36 @@
+import { mathjax } from 'mathjax-full/js/mathjax.js';
+import { TeX } from 'mathjax-full/js/input/tex.js';
+import { SVG } from 'mathjax-full/js/output/svg.js';
+import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor.js';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+
+export function convertLatexToSVG(children: string, fontsize: number, containerRef: React.RefObject<HTMLDivElement>) {
+  const adaptor = browserAdaptor();
+  RegisterHTMLHandler(adaptor);
+
+  const texInput = new TeX({ packages: AllPackages });
+  const svgOutput = new SVG({ fontCache: 'none' });
+
+  const html = mathjax.document(document, {
+    InputJax: texInput,
+    OutputJax: svgOutput,
+  });
+
+  // LaTeX를 SVG로 변환하여 실제 DOM에 추가
+  const node = html.convert(children, { display: true });
+  if (containerRef.current) {
+    containerRef.current.innerHTML = '';
+    containerRef.current.appendChild(node);
+
+    // SVG에 fontsize를 적용
+    const svgElement = containerRef.current.querySelector('svg');
+    if (svgElement) {
+      svgElement.style.fontSize = `${fontsize}px`;
+    }
+
+    return svgElement;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Fixes #6 
- fontsize를 png와 svg저장시에도 적용
- 공통으로 사용하는 LatexToSvg 기능을 `src/lib/LatexToSvg.ts`로 분리